### PR TITLE
Fix: Handle nil deployment outputs gracefully

### DIFF
--- a/pkg/arm/templates/arm.go
+++ b/pkg/arm/templates/arm.go
@@ -462,6 +462,10 @@ func (d *deployer) pollUntilComplete(
 func getOutputs(
 	deployment *resourcesSDK.DeploymentExtended,
 ) (map[string]interface{}, error) {
+	// Check if deployment output is nil as "outputs" section/element is optional in ARM template.
+	if deployment.Properties.Outputs == nil {
+		return map[string]interface{}{}, nil
+	}
 	outputs, ok := deployment.Properties.Outputs.(map[string]interface{})
 	if !ok {
 		return nil, errors.New("error decoding deployment outputs")

--- a/pkg/arm/templates/arm_test.go
+++ b/pkg/arm/templates/arm_test.go
@@ -1,0 +1,52 @@
+package templates
+
+import (
+	"testing"
+
+	resourcesSDK "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOutputs_ValidOutputs(t *testing.T) {
+	deployment := &resourcesSDK.DeploymentExtended{
+		Properties: &resourcesSDK.DeploymentPropertiesExtended{
+			Outputs: map[string]interface{}{
+				"output1": map[string]interface{}{
+					"value": "amaterasu",
+				},
+				"output2": map[string]interface{}{
+					"value": 108,
+				},
+			},
+		},
+	}
+
+	outputs, err := getOutputs(deployment)
+	assert.NoError(t, err)
+	assert.Equal(t, "amaterasu", outputs["output1"])
+	assert.Equal(t, 108, outputs["output2"])
+}
+
+func TestGetOutputs_InvalidOutputs(t *testing.T) {
+	deployment := &resourcesSDK.DeploymentExtended{
+		Properties: &resourcesSDK.DeploymentPropertiesExtended{
+			Outputs: "invalid",
+		},
+	}
+
+	outputs, err := getOutputs(deployment)
+	assert.Error(t, err)
+	assert.Nil(t, outputs)
+}
+
+func TestGetOutputs_NoOutputs(t *testing.T) {
+	deployment := &resourcesSDK.DeploymentExtended{
+		Properties: &resourcesSDK.DeploymentPropertiesExtended{
+			Outputs: nil,
+		},
+	}
+
+	outputs, err := getOutputs(deployment)
+	assert.NoError(t, err)
+	assert.Empty(t, outputs)
+}


### PR DESCRIPTION
## What does this change

In ARM templates, the `outputs` element is used to return values from deployed resources, and its inclusion is optional. However, the current version of the `arm-mixin` incorrectly treats the `outputs` section as mandatory, generating an error when the ARM template being deployed does not define `outputs` section.

![image](https://github.com/user-attachments/assets/609b1f51-6e6f-42ba-a684-fcdf4380dea3)

## What issue does it fix

This pull request resolves the issue of `arm-mixin` deployment failures that occur when the ARM template lacks the `outputs` section. Furthermore, unit test cases have been added to ensure comprehensive coverage of all relevant aspects related to this fix.

## Checklist

- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors](https://porter.sh/src/CONTRIBUTORS.md) list. Thank you for making Porter better! 🙇‍♀️